### PR TITLE
update stats with information about task in crab3 related to McM

### DIFF
--- a/tools/crabUpdate.py
+++ b/tools/crabUpdate.py
@@ -145,9 +145,13 @@ def updateStats( task_name , rid=None):
                  "pdmv_dataset_list" : outs.keys(),
                  "pdmv_dataset_name" : outs.keys()[0],
                  "pdmv_dataset_statuses" : {}, 
-                 "pdmv_completion_in_DAS" : float( min(outs.values()) / statsDoc["pdmv_expected_events"]),
+                 "pdmv_completion_in_DAS" : float("%2.2f" % (100. * min(outs.values()) / statsDoc["pdmv_expected_events"])),
                  "pdmv_monitor_time" : time.asctime(),
                  }
+        ## calculate ETA
+        from statsMonitoring import get_running_days,calc_eta
+        content["pdmv_running_days"] = get_running_days(content["pdmv_submission_date"])
+        content["pdmv_completion_eta_in_DAS"] = calc_eta(content["pdmv_completion_in_DAS"],content["pdmv_running_days"])
         for o in outs: ## this is really a mandatory information
             content["pdmv_dataset_statuses"][o]={"pdmv_open_evts_in_DAS":0,
                                                  "pdmv_evts_in_DAS" : outs[o],
@@ -166,7 +170,8 @@ def updateStats( task_name , rid=None):
         print "making the growth plot"
         plotGrowth(statsDoc,None)
         ## pushing back to the db
-        print "pushing",statsDoc,"back to stats"
+        print "pushing",task_name,"back to stats"
+        pprint.pprint( statsDoc )
         statsCouch.update_file( task_name, json.dumps(statsDoc) )
     else:
         print status 


### PR DESCRIPTION
This is standalone for the moment.
The getter might have to be factorized out to the central getter, with the change to the header argument, which does matter for the crabserver.
This could be included in driveUpdate.py as part of the code under "update" with

from crabUpdate import updateCycle
updateCycle()

needs changes in McM requests schema (private member) and lucene search (search on private) to fully function.
