### PR TITLE
Prevent from sticking an invalid dataset name in the doc

### DIFF
--- a/tools/statsMonitoring.py
+++ b/tools/statsMonitoring.py
@@ -1322,9 +1322,8 @@ def parallel_test(arguments,force=False):
       pass
     
     pdmv_request_dict["pdmv_dataset_name"]=dataset_name
-    if len(dataset_list):
-      pdmv_request_dict["pdmv_dataset_list"]=dataset_list
-    
+    pdmv_request_dict["pdmv_dataset_list"]=dataset_list
+
     deltaUpdate = 0
     ##remove an old field
     if 'pdmv_update_time' in pdmv_request_dict:


### PR DESCRIPTION
if one updates a doc before it is acquired, an un-physical dataset name is registered in the document, creating un-ncessary queries to dbs, and making the history having different datasets in it.
See 7a02d3ffeeb633b64cb9faf751e41049ec6d1b3f.
