### PR TITLE
patch to dataset ordering compareDS (miniaod)

### DIFF
--- a/tools/statsMonitoring.py
+++ b/tools/statsMonitoring.py
@@ -218,19 +218,24 @@ def get_dataset_name(reqname):
       #decision=t1[2] < t2[2]
       def tierP(t):
         tierPriority=[
-                      '/RECO', 
+                      'RECO',
                       'SIM-RECO',
                       'DIGI-RECO',
+                      'AODSIM',
                       'AOD',
                       'SIM-RAW-RECO',
-                      'DQM' ,
                       'GEN-SIM',
                       'RAW-RECO',
                       'USER',
-                      'ALCARECO']
+                      'ALCARECO',
+                      'DQM' ,
+                      'DQMIO',
+                      'MINIAOD',
+                      'MINIAODSIM'
+                      ]
         
         for (p,tier) in enumerate(tierPriority):
-          if tier in t:
+          if tier == t:
             #print t,p
             return p
         #print t


### PR DESCRIPTION
- this function compareDS needs scratching and re-writing
- this PR is intended as a possible pro-tempore solution to assure miniaod are NOT on top of AODSIM,RECO when a single request 
- NOTE: requires processing string to be the same for all data tiers, or, in case of ALCARECO, that processing be a longer string than normal processing string
